### PR TITLE
Switch to pnpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
 
 # local env files
 .env*.local

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This is my personal [homepage](https://ahmedghoneim.site), developer portfolio, 
 First, run the development server:
 
 ```bash
-yarn install
-yarn dev
+pnpm install
+pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.0.4"
-  }
+  },
+  "packageManager": "pnpm@9.15.4"
 }


### PR DESCRIPTION
## Summary
- use pnpm in README
- ignore pnpm debug logs
- specify pnpm as the package manager

## Testing
- `pnpm run lint` *(fails: `next` not found)*
- `pnpm -v`